### PR TITLE
raise skip count in t/001version.t

### DIFF
--- a/t/001version.t
+++ b/t/001version.t
@@ -26,7 +26,7 @@ BEGIN
 # Check lzma_version and LZMA_VERSION are the same.
 
 SKIP: {
-    skip "TEST_SKIP_VERSION_CHECK is set", 1
+    skip "TEST_SKIP_VERSION_CHECK is set", 2
         if $ENV{TEST_SKIP_VERSION_CHECK};
 
     my $lzma_h  = LZMA_VERSION ;


### PR DESCRIPTION

In Debian we are currently applying the following patch to
Compress-Raw-Lzma.
We thought you might be interested in it too.

    Description: raise skip count
     2c922d9 added an additional test in the block guarded by
     TEST_SKIP_VERSION_CHECK but didn't bump the number of skipped test when the
     variable is set which leads to
     .
     t/001version.t .......
     1..5
     ok 1 - use Compress::Raw::Lzma;
     ok 2 # skip TEST_SKIP_VERSION_CHECK is set
     ok 3 # skip Not github
     ok 4 # skip Not github
     Dubious, test returned 1 (wstat 256, 0x100)
     Failed 1/5 subtests
             (less 3 skipped subtests: 1 okay)
    Origin: vendor
    Author: gregor herrmann <gregoa@debian.org>
    Last-Update: 2024-02-19
    

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libcompress-raw-lzma-perl/raw/master/debian/patches/skip-new-test.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
