### PR TITLE
Remove obsolete TODO

### DIFF
--- a/Lzma.xs
+++ b/Lzma.xs
@@ -1052,8 +1052,6 @@ flush(s, output, f=LZMA_FINISH)
             break;
     }
 
-    /* TODO -- ??? */
-    /* RETVAL =  (RETVAL == LZMA_STREAM_END ? LZMA_OK : RETVAL) ; */
     s->last_error = RETVAL ;
 
     s->compressedBytes    += cur_length + increment - s->stream.avail_out ;


### PR DESCRIPTION
The code above will create RETVAL in way that right value is LZMA_STREAM_END or some error. There is not possible return LZMA_OK.

We have LZMA_STREAM_END (or error) in documentation as right return value, so could remove this TODO.